### PR TITLE
Python3 compatibility for KafkLibrary

### DIFF
--- a/KafkaLibrary/Consumer.py
+++ b/KafkaLibrary/Consumer.py
@@ -205,7 +205,7 @@ class Consumer(object):
         messages = self.consumer.poll(timeout_ms=timeout_ms, max_records=max_records)
 
         result = []
-        for _, msg in messages.iteritems():
+        for _, msg in messages.items():
             for item in msg:
                 result.append(item)
         return result

--- a/KafkaLibrary/__init__.py
+++ b/KafkaLibrary/__init__.py
@@ -1,7 +1,7 @@
-from Consumer import Consumer
-from Producer import Producer
+from .Consumer import Consumer
+from .Producer import Producer
 from kafka import TopicPartition
-from version import VERSION
+from .version import VERSION
 
 __version__ = VERSION
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@
 from os.path import join, dirname
 from setuptools import setup
 
-execfile(join(dirname(__file__), 'KafkaLibrary', 'version.py'))
+filename=join(dirname(__file__), 'KafkaLibrary', 'version.py')
+exec(compile(open(filename).read(),filename, 'exec'))
 
 DESCRIPTION = """
 Kafka support for Robot Framework.


### PR DESCRIPTION
few minor changes to support run this library in Python 3 env. Tested with Python 2 too.